### PR TITLE
Task/forward form ref

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "eslint-plugin-jsx-a11y": "~6.2.0",
     "eslint-plugin-react": "~7.15.0",
     "eslint-plugin-react-hooks": "~2.1.0",
-    "flow-bin": "~0.109.0",
+    "flow-bin": "~0.112.0",
     "html-webpack-plugin": "~3.2.0",
     "jest": "~24.9.0",
     "jest-styled-components": "~6.3.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "lattice": "~0.67.0",
     "lodash": "~4.17.0",
     "loglevel": "~1.6.0",
-    "luxon": "~1.19.0",
     "react-jsonschema-form": "~1.8.0"
   },
   "devDependencies": {
@@ -83,6 +82,7 @@
     "jest": "~24.9.0",
     "jest-styled-components": "~6.3.3",
     "lattice-ui-kit": "~0.18.2",
+    "luxon": "~1.21.0",
     "npm-run-all": "~4.1.0",
     "react": "~16.10.0",
     "react-dom": "~16.10.0",

--- a/src/form/stories/index.stories.js
+++ b/src/form/stories/index.stories.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Card } from 'lattice-ui-kit';
+import React, { useRef } from 'react';
+import { Button, Card, CardSegment } from 'lattice-ui-kit';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
@@ -39,4 +39,20 @@ storiesOf('Form', module)
           uiSchema={filesUiSchema}
           onSubmit={action('Submit Form')} />
     </Card>
-  ));
+  ))
+  .add('External Submit', () => {
+    const formRef = useRef();
+    return (
+      <Card>
+        <CardSegment>
+          <Button mode="primary" onClick={() => formRef.current.submit()}>External Submit</Button>
+        </CardSegment>
+        <Form
+            hideSubmit
+            ref={formRef}
+            schema={simpleSchema}
+            uiSchema={simpleUiSchema}
+            onSubmit={action('Submit Form')} />
+      </Card>
+    );
+  });

--- a/src/templates/components/IconButton.js
+++ b/src/templates/components/IconButton.js
@@ -18,6 +18,7 @@ const IconButton = (props :Props) => {
   const { icon, onClick, ...restProps } = props;
   /* eslint-disable react/jsx-props-no-spreading */
   return (
+    // $FlowFixMe
     <StyledButton mode="subtle" onClick={onClick} {...restProps}>
       <FontAwesomeIcon icon={icon} fixedWidth />
     </StyledButton>

--- a/src/widgets/input/BaseInput.js
+++ b/src/widgets/input/BaseInput.js
@@ -73,6 +73,7 @@ class BaseInput extends Component<WidgetProps> {
           readOnly={readonly}
           type={inputType}
           value={value}
+          // $FlowFixMe
           {...inputProps} />
     );
     /* eslint-enable */

--- a/src/widgets/textarea/TextareaWidget.js
+++ b/src/widgets/textarea/TextareaWidget.js
@@ -69,6 +69,7 @@ class TextareaWidget extends Component<WidgetProps> {
           readOnly={readonly}
           rows={options.rows}
           value={value}
+          // $FlowFixMe
           {...restProps} />
     );
     /* eslint-enable */


### PR DESCRIPTION
- expose a forwarded ref down to the RJFS `Form` component to allow for programmatic submits with validation.
- Add `hideSubmit` prop