### PR TITLE
hotfix

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -1,6 +1,6 @@
 /*!
  * 
- * lattice-fabricate - v0.8.0
+ * lattice-fabricate - v0.8.1
  * React HOCs for components dependent on the OpenLattice EDM.
  * https://github.com/openlattice/lattice-fabricate
  * 
@@ -27457,6 +27457,12 @@ function (_Component) {
 
 
 
+var removeEmptyEnums = function removeEmptyEnums(enumOptions) {
+  return enumOptions.filter(function (enumOption) {
+    return enumOption.value !== '';
+  });
+};
+
 var SelectWidget_SelectWidget =
 /*#__PURE__*/
 function (_Component) {
@@ -27506,6 +27512,7 @@ function (_Component) {
           multiple = options.multiple,
           _noOptionsMessage = options.noOptionsMessage;
       var selectOptions = schemaOptions || enumOptions;
+      var noEmptyOptions = removeEmptyEnums(selectOptions);
       var invalid = rawErrors && rawErrors.length;
       var SelectComponent = creatable ? external_lattice_ui_kit_["Creatable"] : external_lattice_ui_kit_["Select"];
       return external_react_default.a.createElement(SelectComponent, {
@@ -27524,7 +27531,7 @@ function (_Component) {
         onBlur: onBlur,
         onChange: this.handleChange,
         onFocus: onFocus,
-        options: selectOptions,
+        options: noEmptyOptions,
         placeholder: placeholder,
         useRawValues: true,
         value: value
@@ -27898,7 +27905,7 @@ var Paged_Paged = function Paged(props) {
 
  // injected by Webpack.DefinePlugin
 
-var version = "v0.8.0";
+var version = "v0.8.1";
 
 /* harmony default export */ var src = __webpack_exports__["default"] = ({
   version: version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lattice-fabricate",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "homepage": "https://github.com/openlattice/lattice-fabricate",
   "description": "React HOCs for components dependent on the OpenLattice EDM.",
   "author": {

--- a/src/widgets/select/SelectWidget.js
+++ b/src/widgets/select/SelectWidget.js
@@ -11,6 +11,8 @@ type Option = {
   value :string | number;
 };
 
+const removeEmptyEnums = (enumOptions :Option[]) => enumOptions.filter((enumOption) => enumOption.value !== '');
+
 class SelectWidget extends Component<WidgetProps> {
   static defaultProps = {
     multiple: false,
@@ -47,6 +49,7 @@ class SelectWidget extends Component<WidgetProps> {
     } = options;
 
     const selectOptions = schemaOptions || enumOptions;
+    const noEmptyOptions = removeEmptyEnums(selectOptions);
     const invalid = rawErrors && rawErrors.length;
     const SelectComponent = creatable ? Creatable : Select;
 
@@ -65,7 +68,7 @@ class SelectWidget extends Component<WidgetProps> {
           onBlur={onBlur}
           onChange={this.handleChange}
           onFocus={onFocus}
-          options={selectOptions}
+          options={noEmptyOptions}
           placeholder={placeholder}
           useRawValues
           value={value} />

--- a/src/widgets/stories/constants/selectSchemas.js
+++ b/src/widgets/stories/constants/selectSchemas.js
@@ -21,10 +21,9 @@ export const schema = {
       title: 'Creatable',
       items: {
         type: 'string',
-        enum: []
+        enum: [''],
       },
       uniqueItems: true,
-      default: []
     },
   },
 };
@@ -46,7 +45,7 @@ export const uiSchema = {
       creatable: true,
       multiple: true,
       noOptionsMessage: 'Type to create',
-      placeholder: '',
+      placeholder: 'Type to create',
     }
   },
 };


### PR DESCRIPTION
So RJSF does not allow empty enum arrays. However, we have a use case to allow for these situations. Unfortunately, they still must be declared with an empty string in the enum in order to pass proper JSON schema validation but the SelectWidget will now filter these out.

```
creatable: {
  type: 'array',
  title: 'Creatable',
  items: {
    type: 'string',
    enum: [''], // required, even though we don't want to display an empty string option
  },
  uniqueItems: true,
}
```

Before
![image](https://user-images.githubusercontent.com/27182199/71206692-01c04400-225a-11ea-86da-955d7a2cab16.png))

After
![image](https://user-images.githubusercontent.com/27182199/71206710-10a6f680-225a-11ea-87ca-3927349183d6.png)

