### PR TITLE
readOnly forms are inert

### DIFF
--- a/src/fields/SchemaField.js
+++ b/src/fields/SchemaField.js
@@ -18,6 +18,7 @@ import {
 
 type Props = {
   disabled :boolean;
+  errorSchema :Object;
   formContext :Object;
   formData :Object;
   hasRemove :boolean;
@@ -76,9 +77,10 @@ class CustomSchemaField extends Component<Props, State> {
   }
 
   render() {
-    const { hasRemove, readonly } = this.props;
+    const { hasRemove, readonly, idSchema } = this.props;
     const { isVisible } = this.state;
     /* eslint-disable react/jsx-props-no-spreading */
+    const { $id } = idSchema;
     return (
       <>
         <SchemaField {...this.props} />
@@ -86,10 +88,12 @@ class CustomSchemaField extends Component<Props, State> {
           <>
             <ActionGutter>
               <IconButton
+                  id={`remove-button-${$id}`}
                   icon={faTrash}
                   onClick={this.openDeleteModal} />
             </ActionGutter>
             <ConfirmDeleteModal
+                id={`remove-modal-${$id}`}
                 onClickPrimary={this.handleConfirmDelete}
                 onClickSecondary={this.closeDeleteModal}
                 onClose={this.closeDeleteModal}

--- a/src/fields/SchemaField.js
+++ b/src/fields/SchemaField.js
@@ -24,6 +24,7 @@ type Props = {
   idSchema :Object;
   onDelete :() => void;
   properties :Object[];
+  readonly :boolean;
   registry :Object;
   required :string;
   title :string;
@@ -75,24 +76,26 @@ class CustomSchemaField extends Component<Props, State> {
   }
 
   render() {
-    const { hasRemove } = this.props;
+    const { hasRemove, readonly } = this.props;
     const { isVisible } = this.state;
     /* eslint-disable react/jsx-props-no-spreading */
     return (
       <>
         <SchemaField {...this.props} />
-        {(hasRemove) && (
-          <ActionGutter>
-            <IconButton
-                icon={faTrash}
-                onClick={this.openDeleteModal} />
-          </ActionGutter>
+        {(hasRemove && !readonly) && (
+          <>
+            <ActionGutter>
+              <IconButton
+                  icon={faTrash}
+                  onClick={this.openDeleteModal} />
+            </ActionGutter>
+            <ConfirmDeleteModal
+                onClickPrimary={this.handleConfirmDelete}
+                onClickSecondary={this.closeDeleteModal}
+                onClose={this.closeDeleteModal}
+                isVisible={isVisible} />
+          </>
         )}
-        <ConfirmDeleteModal
-            onClickPrimary={this.handleConfirmDelete}
-            onClickSecondary={this.closeDeleteModal}
-            onClose={this.closeDeleteModal}
-            isVisible={isVisible} />
       </>
     );
     /* eslint-enable */

--- a/src/fields/SchemaField.js
+++ b/src/fields/SchemaField.js
@@ -88,16 +88,16 @@ class CustomSchemaField extends Component<Props, State> {
           <>
             <ActionGutter>
               <IconButton
-                  id={`remove-button-${$id}`}
                   icon={faTrash}
+                  id={`remove-button-${$id}`}
                   onClick={this.openDeleteModal} />
             </ActionGutter>
             <ConfirmDeleteModal
                 id={`remove-modal-${$id}`}
+                isVisible={isVisible}
                 onClickPrimary={this.handleConfirmDelete}
                 onClickSecondary={this.closeDeleteModal}
-                onClose={this.closeDeleteModal}
-                isVisible={isVisible} />
+                onClose={this.closeDeleteModal} />
           </>
         )}
       </>

--- a/src/fields/SchemaField.test.js
+++ b/src/fields/SchemaField.test.js
@@ -1,0 +1,88 @@
+// @flow
+import React from 'react';
+
+import { faTrash } from '@fortawesome/pro-solid-svg-icons';
+import { mount } from 'enzyme';
+
+import CustomSchemaField from './SchemaField';
+
+import ConfirmDeleteModal from '../templates/array/components/ConfirmDeleteModal';
+import Form from '../form';
+import IconButton from '../templates/components/IconButton';
+
+const arraySchema = {
+  type: 'array',
+  title: 'Array',
+  items: {
+    type: 'string',
+    title: 'string item'
+  },
+  default: ['']
+};
+
+const fixedArraySchema = {
+  type: 'array',
+  title: 'Array',
+  items: [{
+    type: 'string',
+    title: 'string item'
+  }],
+  default: ['']
+};
+
+const unremoveableSchema = {
+  type: 'array',
+  title: 'Array',
+  items: [{
+    type: 'string',
+    title: 'string item'
+  }],
+  default: ['']
+};
+
+const unremoveableUiSchema = {
+  items: {
+    'ui:options': {
+      removable: false
+    }
+  }
+};
+
+const readonlyUiSchema = { ...unremoveableUiSchema, 'ui:readonly': true };
+
+describe('SchemaField', () => {
+
+  describe('default', () => {
+    test('should show add/delete action for array schemas', () => {
+      const wrapper = mount(<Form schema={arraySchema} />);
+      const arraySchemaField = wrapper.find(CustomSchemaField).filter({ hasRemove: true });
+      expect(arraySchemaField).toHaveLength(1);
+      expect(arraySchemaField.children().find('button')).toHaveLength(1);
+      expect(arraySchemaField.children().find(ConfirmDeleteModal)).toHaveLength(1);
+    });
+
+    test('should not show add/delete action for fixed array schemas', () => {
+      const wrapper = mount(<Form schema={fixedArraySchema} />);
+      const deleteButtons = wrapper.find(IconButton).filter({ icon: faTrash });
+      expect(deleteButtons).toHaveLength(0);
+    });
+
+    test('should not show add/delete action for unremovable ui schemas', () => {
+      const wrapper = mount(<Form schema={unremoveableSchema} uiSchema={unremoveableUiSchema} />);
+      const deleteButtons = wrapper.find(IconButton).filter({ icon: faTrash });
+      expect(deleteButtons).toHaveLength(0);
+    });
+  });
+
+  describe('readonly', () => {
+
+    test('should not show add/delete action for readonly array schemas', () => {
+      const wrapper = mount(<Form schema={arraySchema} uiSchema={readonlyUiSchema} />);
+      const arraySchemaField = wrapper.find(CustomSchemaField).filter({ hasRemove: true });
+      expect(arraySchemaField).toHaveLength(1);
+      expect(arraySchemaField).toHaveLength(1);
+      expect(arraySchemaField.children().filter('button')).toHaveLength(0);
+      expect(arraySchemaField.children().find(ConfirmDeleteModal)).toHaveLength(0);
+    });
+  });
+});

--- a/src/form/src/components/Form.js
+++ b/src/form/src/components/Form.js
@@ -24,6 +24,7 @@ type Props = {
   onChange ?:() => void;
   onDiscard ?:() => void;
   onSubmit ?:() => void;
+  readOnly ?:boolean;
 };
 
 type FormProps = {
@@ -41,6 +42,7 @@ const Form = (props :FormProps) => {
     onChange,
     onDiscard,
     onSubmit,
+    readOnly,
     ...restProps
   } = props;
 
@@ -50,7 +52,7 @@ const Form = (props :FormProps) => {
         ArrayFieldTemplate={ArrayFieldTemplate}
         FieldTemplate={FieldTemplate}
         ObjectFieldTemplate={ObjectFieldTemplate}
-        disabled={disabled}
+        disabled={disabled || readOnly}
         fields={fields}
         onChange={onChange}
         onSubmit={onSubmit}
@@ -61,7 +63,7 @@ const Form = (props :FormProps) => {
         // $FlowFixMe
         {...restProps}>
       {
-        (disabled || hideSubmit)
+        (disabled || readOnly || hideSubmit)
           ? <HiddenButton type="submit" />
           : (
             <ActionGroup>
@@ -82,7 +84,8 @@ Form.defaultProps = {
   isSubmitting: false,
   onChange: undefined,
   onDiscard: undefined,
-  onSubmit: undefined
+  onSubmit: undefined,
+  readOnly: false,
 };
 
 /* eslint-enable */

--- a/src/form/stories/FormContainer.js
+++ b/src/form/stories/FormContainer.js
@@ -7,7 +7,7 @@ import { DateTime } from 'luxon';
 
 import entityIndexToIdMap from './constants/entityIndexToIdMap';
 import mockExternalFormData from './constants/mockExternalFormData';
-import { schema, uiSchema } from './constants/dataSchemas';
+import { schema as dataSchema, uiSchema as dataUiSchema } from './constants/dataSchemas';
 import { entitySetIds, propertyTypeIds } from './constants/mockEDM';
 import { ASSOCIATION_ENTITY_SET_NAMES, ENTITY_SET_NAMES, PROPERTY_TYPE_FQNS } from './constants/mockFQNs';
 
@@ -27,6 +27,7 @@ const { COMPLETED_DT_FQN, INDEX_FQN } = PROPERTY_TYPE_FQNS;
 type Props = {
   disabled :boolean;
   onSubmit :(params :any) => void;
+  readOnly :boolean;
 };
 
 type State = {
@@ -36,7 +37,8 @@ type State = {
 class FormContainer extends Component<Props, State> {
 
   static defaultProps = {
-    disabled: false
+    disabled: false,
+    readOnly: false,
   };
 
   state = {
@@ -79,7 +81,7 @@ class FormContainer extends Component<Props, State> {
   }
 
   render() {
-    const { disabled } = this.props;
+    const { disabled, readOnly } = this.props;
     const { formData } = this.state;
     const formContext = {
       addActions: {
@@ -93,14 +95,20 @@ class FormContainer extends Component<Props, State> {
       propertyTypeIds,
     };
 
+    const uiSchema = { ...dataUiSchema };
+    if (readOnly) {
+      uiSchema['ui:readonly'] = true;
+    }
+
     return (
       <Form
           disabled={disabled}
+          readOnly={readOnly}
           formContext={formContext}
           formData={formData}
           onChange={this.updateItemIndicies}
           onSubmit={this.handleSubmit}
-          schema={schema}
+          schema={dataSchema}
           uiSchema={uiSchema} />
     );
   }

--- a/src/form/stories/form.stories.js
+++ b/src/form/stories/form.stories.js
@@ -56,6 +56,9 @@ storiesOf('Form', module)
   .add('Data Processing w/ Edits & Delete', () => (
     <FormContainer disabled onSubmit={action('Submit Form')} />
   ))
+  .add('readonly', () => (
+    <FormContainer readOnly onSubmit={action('Submit Form')} />
+  ))
   .add('Files', () => (
     <Form
         schema={filesSchema}

--- a/src/templates/array/ArrayFieldTemplate.js
+++ b/src/templates/array/ArrayFieldTemplate.js
@@ -16,13 +16,17 @@ const MarginButton = styled(Button)`
   margin-top: 10px;
 `;
 
-const ArrayList = styled.div`
-  > div {
+const ArrayList = styled.ul`
+  margin: 0;
+  padding-inline-start: 0;
+  list-style-type: none;
+
+  > li {
     border-bottom: 1px solid ${NEUTRALS[4]};
     padding: 20px 0;
   }
 
-  > div:last-of-type {
+  > li:last-of-type {
     border-bottom: 0;
     padding-bottom: 0;
   }
@@ -95,6 +99,7 @@ class ArrayFieldTemplate extends Component<Props, State> {
       TitleField,
       uiSchema,
     } = this.props;
+    const { $id } = idSchema;
     const { hasAddedItem } = this.state;
     const {
       addButtonText = 'Add',
@@ -119,6 +124,7 @@ class ArrayFieldTemplate extends Component<Props, State> {
               key={`array-field-description-${idSchema.$id}`} />
         )}
         <ArrayList
+            id={`array-item-list-${idSchema.$id}`}
             key={`array-item-list-${idSchema.$id}`}>
           {items && items.map((itemProps, index) => {
             const options = getUiOptions(uiSchema);
@@ -155,6 +161,7 @@ class ArrayFieldTemplate extends Component<Props, State> {
           })}
           {(canAdd && !readonly) && (
             <MarginButton
+                id={`add-array-item-button-${$id}`}
                 disabled={hasAddedItem}
                 mode="subtle"
                 onClick={this.handleAddClick}>

--- a/src/templates/array/ArrayFieldTemplate.js
+++ b/src/templates/array/ArrayFieldTemplate.js
@@ -1,9 +1,10 @@
 // @flow
 import React, { Component } from 'react';
+import type { ComponentType } from 'react';
+
 import styled from 'styled-components';
 import { Button, Colors } from 'lattice-ui-kit';
 import { getUiOptions } from 'react-jsonschema-form/lib/utils';
-import type { ComponentType } from 'react';
 
 import { ArrayFieldDescription, ArrayFieldTitle, DefaultArrayItem } from './components';
 
@@ -28,18 +29,17 @@ const ArrayList = styled.div`
 `;
 
 type Props = {
-  // disabled ?:boolean,
-  // readonly ?:boolean,
   DescriptionField :ComponentType<any>;
   TitleField :ComponentType<any>;
   canAdd ?:boolean;
-  disabled :boolean;
   className :string;
+  disabled ?:boolean,
   formContext ?:Object;
   formData :Object;
   idSchema :{ $id :string };
   items :Object[];
   onAddClick :(e :SyntheticEvent<HTMLButtonElement>) => void;
+  readonly ?:boolean,
   required ?:boolean;
   schema :Object;
   title ?:string;
@@ -55,8 +55,8 @@ class ArrayFieldTemplate extends Component<Props, State> {
   static defaultProps = {
     canAdd: true,
     formContext: undefined,
-    // disabled: false,
-    // readonly: false,
+    disabled: false,
+    readonly: false,
     required: false,
     title: '',
   };
@@ -88,7 +88,7 @@ class ArrayFieldTemplate extends Component<Props, State> {
       formContext,
       idSchema,
       items,
-      // readonly,
+      readonly,
       required,
       schema,
       title,
@@ -153,7 +153,7 @@ class ArrayFieldTemplate extends Component<Props, State> {
             );
             /* eslint-enable */
           })}
-          {(canAdd) && (
+          {(canAdd && !readonly) && (
             <MarginButton
                 disabled={hasAddedItem}
                 mode="subtle"

--- a/src/templates/array/ArrayFieldTemplate.js
+++ b/src/templates/array/ArrayFieldTemplate.js
@@ -58,8 +58,8 @@ class ArrayFieldTemplate extends Component<Props, State> {
 
   static defaultProps = {
     canAdd: true,
-    formContext: undefined,
     disabled: false,
+    formContext: undefined,
     readonly: false,
     required: false,
     title: '',
@@ -86,9 +86,10 @@ class ArrayFieldTemplate extends Component<Props, State> {
 
   render() {
     const {
+      DescriptionField,
+      TitleField,
       canAdd,
       className,
-      DescriptionField,
       formContext,
       idSchema,
       items,
@@ -96,7 +97,6 @@ class ArrayFieldTemplate extends Component<Props, State> {
       required,
       schema,
       title,
-      TitleField,
       uiSchema,
     } = this.props;
     const { $id } = idSchema;
@@ -110,16 +110,16 @@ class ArrayFieldTemplate extends Component<Props, State> {
     return (
       <div className={className}>
         <ArrayFieldTitle
+            TitleField={TitleField}
             idSchema={idSchema}
             key={`array-field-title-${idSchema.$id}`}
             required={required}
-            title={uiSchema['ui:title'] || title}
-            TitleField={TitleField} />
+            title={uiSchema['ui:title'] || title} />
 
         {(uiSchema['ui:description'] || schema.description) && (
           <ArrayFieldDescription
-              description={uiSchema['ui:description'] || schema.description}
               DescriptionField={DescriptionField}
+              description={uiSchema['ui:description'] || schema.description}
               idSchema={idSchema}
               key={`array-field-description-${idSchema.$id}`} />
         )}
@@ -161,8 +161,8 @@ class ArrayFieldTemplate extends Component<Props, State> {
           })}
           {(canAdd && !readonly) && (
             <MarginButton
-                id={`add-array-item-button-${$id}`}
                 disabled={hasAddedItem}
+                id={`add-array-item-button-${$id}`}
                 mode="subtle"
                 onClick={this.handleAddClick}>
               {addButtonText}

--- a/src/templates/array/ArrayFieldTemplate.test.js
+++ b/src/templates/array/ArrayFieldTemplate.test.js
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import { mount } from 'enzyme';
+
+import Form from '../../form';
+
+const arraySchema = {
+  type: 'array',
+  title: 'Array',
+  items: {
+    type: 'string',
+    title: 'string item'
+  },
+  default: ['']
+};
+
+const readonlyUiSchema = {
+  'ui:readonly': true
+};
+
+describe('ArrayFieldTemplate', () => {
+  describe('default', () => {
+    test('should display add button', () => {
+      const wrapper = mount(<Form schema={arraySchema} />);
+      expect(wrapper.find('button#add-array-item-button-root')).toHaveLength(1);
+    });
+  });
+
+  describe('readonly', () => {
+    test('should not display add button when readonly', () => {
+      const wrapper = mount(<Form schema={arraySchema} uiSchema={readonlyUiSchema} />);
+      expect(wrapper.find('button#add-array-item-button-root')).toHaveLength(0);
+    });
+  });
+});

--- a/src/templates/array/components/DefaultArrayItem.js
+++ b/src/templates/array/components/DefaultArrayItem.js
@@ -50,9 +50,9 @@ class DefaultArrayItem extends Component <Props> {
 
   static defaultProps = {
     addAction: undefined,
-    removeAddedItem: undefined,
     addState: false,
     isAdding: false,
+    removeAddedItem: undefined,
     showIndex: true,
   };
 
@@ -103,7 +103,7 @@ class DefaultArrayItem extends Component <Props> {
     const {
       addState,
       isAdding,
-      orderable
+      orderable,
     } = this.props;
 
     return addState && (
@@ -152,7 +152,7 @@ class DefaultArrayItem extends Component <Props> {
       onReorderClick,
       orderable,
       readonly,
-      showIndex
+      showIndex,
     } = this.props;
 
     return (
@@ -161,13 +161,13 @@ class DefaultArrayItem extends Component <Props> {
           { orderable && (
             <ActionGutter>
               <IconButton
-                  icon={faChevronUp}
                   disabled={disabled || readonly || !hasMoveUp}
+                  icon={faChevronUp}
                   onClick={onReorderClick(index, index - 1)} />
               <IndexCircle index={index + 1} visible={showIndex} />
               <IconButton
-                  icon={faChevronDown}
                   disabled={disabled || readonly || !hasMoveDown}
+                  icon={faChevronDown}
                   onClick={onReorderClick(index, index + 1)} />
             </ActionGutter>
           )}

--- a/src/templates/array/components/DefaultArrayItem.js
+++ b/src/templates/array/components/DefaultArrayItem.js
@@ -156,7 +156,7 @@ class DefaultArrayItem extends Component <Props> {
     } = this.props;
 
     return (
-      <div>
+      <li>
         <ItemWrapper className={className}>
           { orderable && (
             <ActionGutter>
@@ -174,7 +174,7 @@ class DefaultArrayItem extends Component <Props> {
           { this.renderChildren() }
         </ItemWrapper>
         { this.renderSubmitButton() }
-      </div>
+      </li>
     );
   }
 }

--- a/src/templates/object/ObjectFieldTemplate.js
+++ b/src/templates/object/ObjectFieldTemplate.js
@@ -3,21 +3,22 @@ import React, { Component } from 'react';
 import type { ComponentType } from 'react';
 
 import isFunction from 'lodash/isFunction';
-import { Button } from 'lattice-ui-kit';
 import { faPen } from '@fortawesome/pro-solid-svg-icons';
 import { fromJS, set } from 'immutable';
+import { Button } from 'lattice-ui-kit';
 import { getUiOptions } from 'react-jsonschema-form/lib/utils';
 
-import IconButton from '../components/IconButton';
-import ActionGutter from '../components/styled/ActionGutter';
-import { ActionGroup } from '../../form/src/components/styled';
 import { parseIdIndex } from './utils';
+
+import ActionGutter from '../components/styled/ActionGutter';
+import IconButton from '../components/IconButton';
+import { ActionGroup } from '../../form/src/components/styled';
 import {
   findEntityAddressKeyFromMap,
+  parseIdSchemaPath,
   processEntityDataForPartialReplace,
   replaceEntityAddressKeys,
   wrapFormDataInPageSection,
-  parseIdSchemaPath,
 } from '../../utils/DataProcessingUtils';
 
 type Props = {
@@ -29,6 +30,7 @@ type Props = {
   formData :Object;
   idSchema :Object;
   properties :Object[];
+  readonly :boolean;
   required :string;
   title :string;
   uiSchema :Object;
@@ -107,11 +109,11 @@ class ObjectFieldTemplate extends Component<Props, State> {
   }
 
   renderActionGutter = () => {
-    const { uiSchema, disabled } = this.props;
+    const { uiSchema, disabled, readonly } = this.props;
     const { isEditing } = this.state;
     const { editable } :Object = getUiOptions(uiSchema);
 
-    return (editable && disabled)
+    return (editable && disabled && !readonly)
       ? (
         <ActionGutter>
           <IconButton icon={faPen} onClick={this.enableFields} disabled={isEditing} />

--- a/src/templates/object/ObjectFieldTemplate.js
+++ b/src/templates/object/ObjectFieldTemplate.js
@@ -133,10 +133,10 @@ class ObjectFieldTemplate extends Component<Props, State> {
     const { formData, formContext, idSchema } = this.props;
     const {
       editAction,
+      entityIndexToIdMap,
       entitySetIds,
       mappers,
       propertyTypeIds,
-      entityIndexToIdMap,
     } = formContext;
 
     // get array index if relevant
@@ -172,7 +172,7 @@ class ObjectFieldTemplate extends Component<Props, State> {
         entityData: editedEntityData,
         formData: formattedData,
         path,
-        properties: draftFormData
+        properties: draftFormData,
       });
       this.disableFields();
     }
@@ -187,9 +187,9 @@ class ObjectFieldTemplate extends Component<Props, State> {
     return isEditing && (
       <ActionGroup className="column-span-12" noPadding>
         <Button
+            isLoading={updateState}
             mode="primary"
-            onClick={this.commitDraftFormData}
-            isLoading={updateState}>
+            onClick={this.commitDraftFormData}>
           Save
         </Button>
         <Button onClick={this.disableFields}>Discard</Button>
@@ -232,7 +232,7 @@ class ObjectFieldTemplate extends Component<Props, State> {
                 ...contentProps,
                 disabled: disabled && !isEditing,
                 formData: tempFormData,
-                onChange: this.createDraftChangeHandler(contentName)
+                onChange: this.createDraftChangeHandler(contentName),
               };
               return React.cloneElement(content, state);
             }

--- a/src/templates/object/ObjectFieldTemplate.js
+++ b/src/templates/object/ObjectFieldTemplate.js
@@ -109,14 +109,20 @@ class ObjectFieldTemplate extends Component<Props, State> {
   }
 
   renderActionGutter = () => {
-    const { uiSchema, disabled, readonly } = this.props;
+    const {
+      disabled,
+      idSchema,
+      readonly,
+      uiSchema,
+    } = this.props;
+    const { $id } = idSchema;
     const { isEditing } = this.state;
     const { editable } :Object = getUiOptions(uiSchema);
 
     return (editable && disabled && !readonly)
       ? (
         <ActionGutter>
-          <IconButton icon={faPen} onClick={this.enableFields} disabled={isEditing} />
+          <IconButton id={`edit-button-${$id}`} icon={faPen} onClick={this.enableFields} disabled={isEditing} />
         </ActionGutter>
       )
       : null;

--- a/src/templates/object/ObjectFieldTemplate.test.js
+++ b/src/templates/object/ObjectFieldTemplate.test.js
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import { mount } from 'enzyme';
+
+import Form from '../../form';
+
+const objectSchema = {
+  type: 'object',
+  properties: {
+    object: {
+      type: 'string',
+      title: 'string item'
+    }
+  },
+};
+
+const uiSchema = {
+  'ui:options': {
+    editable: true
+  }
+};
+
+const readonlyUiSchema = {
+  'ui:readonly': true,
+  'ui:options': {
+    editable: true
+  }
+};
+
+describe('ObjectFieldTemplate', () => {
+  describe('editable', () => {
+    test('should display edit button when disabled and editable', () => {
+      const wrapper = mount(<Form disabled schema={objectSchema} uiSchema={uiSchema} />);
+      expect(wrapper.find('button#edit-button-root')).toHaveLength(1);
+    });
+  });
+
+  describe('readonly', () => {
+    test('should not display edit button when readonly', () => {
+      const wrapper = mount(<Form disabled schema={objectSchema} uiSchema={readonlyUiSchema} />);
+      expect(wrapper.find('button#edit-button-root')).toHaveLength(0);
+    });
+  });
+});

--- a/src/widgets/radio/src/components/__snapshots__/OtherRadioWidget.test.js.snap
+++ b/src/widgets/radio/src/components/__snapshots__/OtherRadioWidget.test.js.snap
@@ -42,6 +42,7 @@ exports[`OtherRadioWidget should match snapshot 1`] = `
       forwardedRef={null}
       hideSubmit={false}
       isSubmitting={false}
+      readOnly={false}
       schema={
         Object {
           "properties": Object {
@@ -2949,61 +2950,6 @@ exports[`OtherRadioWidget should match snapshot 1`] = `
                                   </div>
                                 </FieldTemplate>
                               </SchemaField>
-                              <ConfirmDeleteModal
-                                isVisible={false}
-                                onClickPrimary={[Function]}
-                                onClickSecondary={[Function]}
-                                onClose={[Function]}
-                              >
-                                <Modal
-                                  isVisible={false}
-                                  onClickPrimary={[Function]}
-                                  onClickSecondary={[Function]}
-                                  onClose={[Function]}
-                                  shouldBeCentered={true}
-                                  shouldCloseOnEscape={true}
-                                  shouldCloseOnOutsideClick={true}
-                                  shouldStretchButtons={false}
-                                  textPrimary="Delete"
-                                  textSecondary="Cancel"
-                                  textTitle="Confirm Delete"
-                                  viewportScrolling={false}
-                                  withFooter={true}
-                                  withHeader={true}
-                                >
-                                  <Overlay
-                                    isScrollable={false}
-                                    isVisible={false}
-                                    onClose={[Function]}
-                                    shouldCloseOnClick={true}
-                                    transparent={false}
-                                  >
-                                    <CSSTransition
-                                      classNames="luk-fade"
-                                      in={false}
-                                      mountOnEnter={true}
-                                      timeout={200}
-                                      unmountOnExit={true}
-                                    >
-                                      <Transition
-                                        appear={false}
-                                        enter={true}
-                                        exit={true}
-                                        in={false}
-                                        mountOnEnter={true}
-                                        onEnter={[Function]}
-                                        onEntered={[Function]}
-                                        onEntering={[Function]}
-                                        onExit={[Function]}
-                                        onExited={[Function]}
-                                        onExiting={[Function]}
-                                        timeout={200}
-                                        unmountOnExit={true}
-                                      />
-                                    </CSSTransition>
-                                  </Overlay>
-                                </Modal>
-                              </ConfirmDeleteModal>
                             </CustomSchemaField>
                           </div>
                         </ObjectFieldTemplate>
@@ -3012,61 +2958,6 @@ exports[`OtherRadioWidget should match snapshot 1`] = `
                     </div>
                   </FieldTemplate>
                 </SchemaField>
-                <ConfirmDeleteModal
-                  isVisible={false}
-                  onClickPrimary={[Function]}
-                  onClickSecondary={[Function]}
-                  onClose={[Function]}
-                >
-                  <Modal
-                    isVisible={false}
-                    onClickPrimary={[Function]}
-                    onClickSecondary={[Function]}
-                    onClose={[Function]}
-                    shouldBeCentered={true}
-                    shouldCloseOnEscape={true}
-                    shouldCloseOnOutsideClick={true}
-                    shouldStretchButtons={false}
-                    textPrimary="Delete"
-                    textSecondary="Cancel"
-                    textTitle="Confirm Delete"
-                    viewportScrolling={false}
-                    withFooter={true}
-                    withHeader={true}
-                  >
-                    <Overlay
-                      isScrollable={false}
-                      isVisible={false}
-                      onClose={[Function]}
-                      shouldCloseOnClick={true}
-                      transparent={false}
-                    >
-                      <CSSTransition
-                        classNames="luk-fade"
-                        in={false}
-                        mountOnEnter={true}
-                        timeout={200}
-                        unmountOnExit={true}
-                      >
-                        <Transition
-                          appear={false}
-                          enter={true}
-                          exit={true}
-                          in={false}
-                          mountOnEnter={true}
-                          onEnter={[Function]}
-                          onEntered={[Function]}
-                          onEntering={[Function]}
-                          onExit={[Function]}
-                          onExited={[Function]}
-                          onExiting={[Function]}
-                          timeout={200}
-                          unmountOnExit={true}
-                        />
-                      </CSSTransition>
-                    </Overlay>
-                  </Modal>
-                </ConfirmDeleteModal>
               </CustomSchemaField>
               <ActionGroup>
                 <StyledComponent

--- a/src/widgets/radio/src/components/__snapshots__/RadioWidget.test.js.snap
+++ b/src/widgets/radio/src/components/__snapshots__/RadioWidget.test.js.snap
@@ -39,6 +39,7 @@ exports[`RadioWidget should match snapshot 1`] = `
       forwardedRef={null}
       hideSubmit={false}
       isSubmitting={false}
+      readOnly={false}
       schema={
         Object {
           "properties": Object {
@@ -2759,61 +2760,6 @@ exports[`RadioWidget should match snapshot 1`] = `
                                   </div>
                                 </FieldTemplate>
                               </SchemaField>
-                              <ConfirmDeleteModal
-                                isVisible={false}
-                                onClickPrimary={[Function]}
-                                onClickSecondary={[Function]}
-                                onClose={[Function]}
-                              >
-                                <Modal
-                                  isVisible={false}
-                                  onClickPrimary={[Function]}
-                                  onClickSecondary={[Function]}
-                                  onClose={[Function]}
-                                  shouldBeCentered={true}
-                                  shouldCloseOnEscape={true}
-                                  shouldCloseOnOutsideClick={true}
-                                  shouldStretchButtons={false}
-                                  textPrimary="Delete"
-                                  textSecondary="Cancel"
-                                  textTitle="Confirm Delete"
-                                  viewportScrolling={false}
-                                  withFooter={true}
-                                  withHeader={true}
-                                >
-                                  <Overlay
-                                    isScrollable={false}
-                                    isVisible={false}
-                                    onClose={[Function]}
-                                    shouldCloseOnClick={true}
-                                    transparent={false}
-                                  >
-                                    <CSSTransition
-                                      classNames="luk-fade"
-                                      in={false}
-                                      mountOnEnter={true}
-                                      timeout={200}
-                                      unmountOnExit={true}
-                                    >
-                                      <Transition
-                                        appear={false}
-                                        enter={true}
-                                        exit={true}
-                                        in={false}
-                                        mountOnEnter={true}
-                                        onEnter={[Function]}
-                                        onEntered={[Function]}
-                                        onEntering={[Function]}
-                                        onExit={[Function]}
-                                        onExited={[Function]}
-                                        onExiting={[Function]}
-                                        timeout={200}
-                                        unmountOnExit={true}
-                                      />
-                                    </CSSTransition>
-                                  </Overlay>
-                                </Modal>
-                              </ConfirmDeleteModal>
                             </CustomSchemaField>
                           </div>
                         </ObjectFieldTemplate>
@@ -2822,61 +2768,6 @@ exports[`RadioWidget should match snapshot 1`] = `
                     </div>
                   </FieldTemplate>
                 </SchemaField>
-                <ConfirmDeleteModal
-                  isVisible={false}
-                  onClickPrimary={[Function]}
-                  onClickSecondary={[Function]}
-                  onClose={[Function]}
-                >
-                  <Modal
-                    isVisible={false}
-                    onClickPrimary={[Function]}
-                    onClickSecondary={[Function]}
-                    onClose={[Function]}
-                    shouldBeCentered={true}
-                    shouldCloseOnEscape={true}
-                    shouldCloseOnOutsideClick={true}
-                    shouldStretchButtons={false}
-                    textPrimary="Delete"
-                    textSecondary="Cancel"
-                    textTitle="Confirm Delete"
-                    viewportScrolling={false}
-                    withFooter={true}
-                    withHeader={true}
-                  >
-                    <Overlay
-                      isScrollable={false}
-                      isVisible={false}
-                      onClose={[Function]}
-                      shouldCloseOnClick={true}
-                      transparent={false}
-                    >
-                      <CSSTransition
-                        classNames="luk-fade"
-                        in={false}
-                        mountOnEnter={true}
-                        timeout={200}
-                        unmountOnExit={true}
-                      >
-                        <Transition
-                          appear={false}
-                          enter={true}
-                          exit={true}
-                          in={false}
-                          mountOnEnter={true}
-                          onEnter={[Function]}
-                          onEntered={[Function]}
-                          onEntering={[Function]}
-                          onExit={[Function]}
-                          onExited={[Function]}
-                          onExiting={[Function]}
-                          timeout={200}
-                          unmountOnExit={true}
-                        />
-                      </CSSTransition>
-                    </Overlay>
-                  </Modal>
-                </ConfirmDeleteModal>
               </CustomSchemaField>
               <ActionGroup>
                 <StyledComponent


### PR DESCRIPTION
- `<Form readOnly />` disables the form and hides submit button
- `'ui:readonly' : true` at top level of uiSchema sets all fields to be readonly.
- `readonly` fields do not surface any functionality from `editable` ObjectFields, or `addable`, `removable`, `orderable` ArrayFields.

~TODO: Tests~